### PR TITLE
Fixing the double announce list when editing a torrent file

### DIFF
--- a/bin/nt.js
+++ b/bin/nt.js
@@ -308,7 +308,7 @@ function edit() {
     }
 
     if (options.announceList) {
-      metadata.announceList = options.announceList;
+      metadata["announce-list"] = options.announceList;
     }
 
     if (options.comment) {


### PR DESCRIPTION
![Image of the problem](http://i.imgur.com/NDNtlHp.png)